### PR TITLE
Aligning syntax with sbt 0.13 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ version := "0.1-SNAPSHOT"
 
 organization := "org.example"
 
-scalaVersion in ThisBuild := "2.11.7"
+scalaVersion in ThisBuild := "2.11.8"
 
 val flinkVersion = "1.3.0"
 
@@ -23,7 +23,10 @@ lazy val root = (project in file(".")).
 mainClass in assembly := Some("org.example.Job")
 
 // make run command include the provided dependencies
-run in Compile <<= Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run))
+run in Compile := Defaults.runTask(fullClasspath in Compile,
+                                   mainClass in (Compile, run),
+                                   runner in (Compile,run)
+                                  ).evaluated
 
 // exclude Scala library from assembly
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13


### PR DESCRIPTION

This minor PR just aligns a bit of syntax with conventions of sbt 0.13. 

1) specifies the sbt version in project/build.properties

In order to make sure build results are consistent, as mentioned here: [http://www.scala-sbt.org/0.13/docs/Basic-Def.html#Specifying+the+sbt+version](http://www.scala-sbt.org/0.13/docs/Basic-Def.html#Specifying+the+sbt+version)


2) replaces the deprecated `<<=` operator with `:=`

The previous syntax was triggering this warning because of the re-definition of the `run` task: 

```
build.sbt:26: warning: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newV
alue })`.
See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
```

The new `run` task is exactly identical to the previous one, though the deprecation warning gone. 

3) bumps scala version from 2.11.7 to 2.11.8
(while I was at it...)

